### PR TITLE
Allow for an optional FBO parameter for SendImage()

### DIFF
--- a/SpoutSDK/Source/SpoutSDK.cpp
+++ b/SpoutSDK/Source/SpoutSDK.cpp
@@ -323,7 +323,8 @@ bool Spout::SendImage(const unsigned char* pixels,
 					  unsigned int width, 
 					  unsigned int height, 
 					  GLenum glFormat, 
-					  bool bInvert)
+					  bool bInvert,
+					  GLuint HostFBO)
 {
 	bool bResult = true;
 	unsigned char * buffer = NULL;
@@ -347,7 +348,7 @@ bool Spout::SendImage(const unsigned char* pixels,
 
 	if(bDxInitOK) {
 		// Write the pixel data to the rgba shared texture from the user pixel format
-		bResult = interop.WriteTexturePixels(pixels, width, height, glformat, bInvert);
+		bResult = interop.WriteTexturePixels(pixels, width, height, glformat, bInvert, HostFBO);
 	}
 	else {
 		// Write the pixel data to the rgba shared memory from the user pixel format

--- a/SpoutSDK/Source/SpoutSDK.h
+++ b/SpoutSDK/Source/SpoutSDK.h
@@ -78,7 +78,7 @@ class SPOUT_DLLEXP Spout {
 	bool UpdateSender  (const char* Sendername, unsigned int width, unsigned int height);
 	void ReleaseSender (DWORD dwMsec = 0);
 	bool SendTexture   (GLuint TextureID, GLuint TextureTarget, unsigned int width, unsigned int height, bool bInvert=true, GLuint HostFBO=0);
-	bool SendImage     (const unsigned char* pixels, unsigned int width, unsigned int height, GLenum glFormat = GL_RGBA, bool bInvert=false);
+	bool SendImage     (const unsigned char* pixels, unsigned int width, unsigned int height, GLenum glFormat = GL_RGBA, bool bInvert=false, GLuint HostFBO = 0);
 
 	// Receiver
 	bool CreateReceiver (char* Sendername, unsigned int &width, unsigned int &height, bool bUseActive = false);

--- a/SpoutSDK/Source/SpoutSender.cpp
+++ b/SpoutSDK/Source/SpoutSender.cpp
@@ -87,9 +87,9 @@ void SpoutSender::ReleaseSender(DWORD dwMsec)
 
 
 //---------------------------------------------------------
-bool SpoutSender::SendImage(const unsigned char* pixels, unsigned int width, unsigned int height, GLenum glFormat, bool bInvert)
+bool SpoutSender::SendImage(const unsigned char* pixels, unsigned int width, unsigned int height, GLenum glFormat, bool bInvert, GLuint HostFBO)
 {
-	return spout.SendImage(pixels, width, height, glFormat, bInvert);
+	return spout.SendImage(pixels, width, height, glFormat, bInvert, HostFBO);
 }
 
 

--- a/SpoutSDK/Source/SpoutSender.h
+++ b/SpoutSDK/Source/SpoutSender.h
@@ -44,7 +44,7 @@ class SPOUT_DLLEXP SpoutSender {
 	bool UpdateSender(const char *Sendername, unsigned int width, unsigned int height);
 	void ReleaseSender(DWORD dwMsec = 0);
 
-	bool SendImage(const unsigned char* pixels, unsigned int width, unsigned int height, GLenum glFormat = GL_RGBA, bool bInvert=false);
+	bool SendImage(const unsigned char* pixels, unsigned int width, unsigned int height, GLenum glFormat = GL_RGBA, bool bInvert=false, GLuint HostFBO = 0);
 	bool SendTexture(GLuint TextureID, GLuint TextureTarget, unsigned int width, unsigned int height, bool bInvert=true, GLuint HostFBO = 0);
 	bool DrawToSharedTexture(GLuint TextureID, GLuint TextureTarget, unsigned int width, unsigned int height, float max_x = 1.0, float max_y = 1.0, float aspect = 1.0, bool bInvert = false, GLuint HostFBO = 0);
 


### PR DESCRIPTION
Allow for an optional FBO parameter for `SendImage()`, since `WriteTexturePixels()` is used and supports it. This is also consistent with `ReceiveImage()`.