### PR TITLE
restore HostFBO in spoutGLDXinterop::WriteDX11texture when !bInvert

### DIFF
--- a/SpoutSDK/Source/SpoutGLDXinterop.cpp
+++ b/SpoutSDK/Source/SpoutGLDXinterop.cpp
@@ -2377,6 +2377,8 @@ bool spoutGLDXinterop::WriteDX11texture (GLuint TextureID, GLuint TextureTarget,
 				else {
 					PrintFBOstatus(status);
 				}
+				// restore the previous fbo - default is 0
+				glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, HostFBO);
 			}
 		}
 		g_pImmediateContext->Unmap(g_pStagingTexture, 0);


### PR DESCRIPTION
glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, HostFBO) was missing in one section of code.