### PR TITLE
create a cmake-package of (optionally) all targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,4 +55,85 @@ if(SPOUT_BUILD_SPOUTDX OR SPOUT_BUILD_SPOUTDX_EXAMPLES)
 add_subdirectory(SPOUTSDK/SpoutDirectX/SpoutDX)
 endif()
 
+include(GNUInstallDirs)
 
+if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
+	set(Spout2InstallTargets Spout Spout_static)
+
+	if(SPOUT_BUILD_SPOUTDX OR SPOUT_BUILD_SPOUTDX_EXAMPLES)
+		list(APPEND Spout2InstallTargets SpoutDX)
+	endif()
+
+	if(SPOUT_BUILD_LIBRARY)
+		list(APPEND Spout2InstallTargets SpoutLibrary)
+	endif()
+
+	install(
+		TARGETS
+			${Spout2InstallTargets}
+		EXPORT
+			spout2-targets
+		LIBRARY
+			DESTINATION ${CMAKE_INSTALL_LIBDIR}
+		ARCHIVE
+			DESTINATION ${CMAKE_INSTALL_LIBDIR}
+		RUNTIME
+			DESTINATION ${CMAKE_INSTALL_BINDIR}
+		INCLUDES
+			DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+	)
+
+	install(
+		EXPORT
+			spout2-targets
+		DESTINATION
+			${CMAKE_INSTALL_LIBDIR}/cmake/spout2
+		NAMESPACE
+			Spout2::
+	)
+
+	install(
+		FILES
+			${CMAKE_CURRENT_SOURCE_DIR}/spout2-config.cmake
+		DESTINATION
+			${CMAKE_INSTALL_LIBDIR}/cmake/spout2
+	)
+endif()
+
+if(NOT SKIP_INSTALL_HEADERS AND NOT SKIP_INSTALL_ALL)
+	install(
+		FILES
+			SPOUTSDK/SpoutGL/Spout.h
+			SPOUTSDK/SpoutGL/SpoutCommon.h
+			SPOUTSDK/SpoutGL/SpoutCopy.h
+			SPOUTSDK/SpoutGL/SpoutDirectX.h
+			SPOUTSDK/SpoutGL/SpoutFrameCount.h
+			SPOUTSDK/SpoutGL/SpoutGL.h
+			SPOUTSDK/SpoutGL/SpoutGLextensions.h
+			SPOUTSDK/SpoutGL/SpoutReceiver.h
+			SPOUTSDK/SpoutGL/SpoutSender.h
+			SPOUTSDK/SpoutGL/SpoutSenderNames.h
+			SPOUTSDK/SpoutGL/SpoutSharedMemory.h
+			SPOUTSDK/SpoutGL/SpoutUtils.h
+		DESTINATION
+			${CMAKE_INSTALL_PREFIX}/include/Spout2
+	)
+
+	if(SPOUT_BUILD_SPOUTDX OR SPOUT_BUILD_SPOUTDX_EXAMPLES)
+		install(
+			FILES
+				SPOUTSDK/SpoutDirectX/SpoutDX/SpoutDX.h
+			DESTINATION
+				${CMAKE_INSTALL_PREFIX}/include/Spout2/SpoutDX
+		)
+	endif()
+
+	if(SPOUT_BUILD_LIBRARY)
+		install(
+			FILES
+				SPOUTSDK/SpoutLibrary/SpoutLibrary.h
+			DESTINATION
+				${CMAKE_INSTALL_PREFIX}/include/Spout2/SpoutLibrary
+		)
+	endif()
+endif()

--- a/spout2-config.cmake
+++ b/spout2-config.cmake
@@ -1,0 +1,1 @@
+include(${CMAKE_CURRENT_LIST_DIR}/spout2-targets.cmake)


### PR DESCRIPTION
PR introduces an installable [CMake Package](https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html) consisting of the various library & DLL targets created by CMakeLists.txt.

Compared to the project files generated by CMake before there is a new target called *INSTALL* which, when ran, will build all targets and install the results to the path defined by **CMAKE_INSTALL_PREFIX** variable.  *CMAKE_INSTALL_PREFIX* may be set in the CMake-UI or using the CLI by specifying e.g. `-DCMAKE_INSTALL_PREFIX=C:/example_path/`

Installed directory structure looks as follows;
* <CMAKE_INSTALL_PREFIX>
  * bin
    * dynamic libraries
  * include
    * Spout2
      *   Spout include files, Spout.h etc. Also two subdirectories for SpoutDX and SpoutLibrary
  * lib
    * static libraries, also a subdirectory called 'cmake' that contains package configuration

The following snippet, placed in a CMakeLists.txt file, will automatically load the configuration from the package.
     `find_package(
	spout2
	PATHS
		C:/example_path/
	CONFIG
	REQUIRED
)`

If the package is found and loaded correctly, the following targets are exposed; 
* Spout2::Spout 
* Spout2::Spout_static 
* Spout2::SpoutDX 
* Spout2::SpoutLibrary

Which may be linked against using the following snippet `target_link_libraries(
	target_name
	PRIVATE
		Spout2::Spout_static
)`
Include directories are imported automatically so after linking one can use ` #include <Spout2/Spout.h>`

The install configuration respects the existing options so **SpoutDX** and **SpoutLibrary** are only built and installed if so specified. Furthermore specific install steps can be disabled by specifying one or more of the following options, this is done mainly for VCKPG integration.
* SKIP_INSTALL_HEADERS 
* SKIP_INSTALL_LIBRARIES
* SKIP_INSTALL_ALL 

The major benefit of this PR is that Spout2 may more easily be used with package managers such as [VCPKG](https://github.com/microsoft/vcpkg) or [Conan](http://conan.io/).