### PR TITLE
Maintenance update

### DIFF
--- a/SPOUTSDK/SpoutGL/Spout.cpp
+++ b/SPOUTSDK/SpoutGL/Spout.cpp
@@ -203,6 +203,8 @@
 //		22.06.21	- Move code for GetSenderCount and GetSender to SpoutSenderNames class
 //		03.07.21	- Use changed SpoutSenderNames "GetSender" function name.
 //		04.07.21	- Additional code comments concerning update in ReceiveTexture.
+//		12.08.21	- CreateReceiver - Revise CreateReceiver to avoid switch to active
+//					  if the selected sender closes.
 //
 // ====================================================================================
 /*
@@ -1304,16 +1306,7 @@ bool Spout::CreateReceiver(char* sendername, unsigned int &width, unsigned int &
 	// Make sure OpenGL and DirectX are initialized
 	if (!OpenSpout())
 		return false;
-
-	// Use the active sender if the user wants it or the sender name is not set
-	if (bUseActive || sendername[0] == 0) {
-		m_SenderNameSetup[0] = 0;
-	}
-	else {
-		// Try to find the sender with the name sent
-		strcpy_s(m_SenderNameSetup, 256, sendername);
-	}
-
+	
 	if (ReceiveSenderData()) {
 		// The sender name, width, height, format, shared texture handle
 		// and shared texture pointer have been retrieved.
@@ -2028,9 +2021,7 @@ bool Spout::ReceiveSenderData()
 		// Connected and intialized
 		// Sender name, width, height, format, texture pointer and share handle have been retrieved
 
-		// LJ DEBUG
 		// printf("    m_dxShareHandle = 0x%7X : m_pSharedTexture = 0x%7X\n", PtrToUint(m_dxShareHandle), PtrToUint(m_pSharedTexture));
-
 		// ID3D11Texture2D * texturePointer = m_pSharedTexture;
 		// D3D11_TEXTURE2D_DESC td;
 		// texturePointer->GetDesc(&td);

--- a/SPOUTSDK/SpoutGL/SpoutFrameCount.cpp
+++ b/SPOUTSDK/SpoutGL/SpoutFrameCount.cpp
@@ -38,6 +38,7 @@
 //		07.04.21	- CloseFrameSync public for use by other classes
 //		17.04.21	- WaitFrameSync - close handle on error
 //		21.07.21	- Remove debug comment
+//		10.08.21	- Default m_bIsNewFrame, assume true to allow for apps without frame count
 //
 // ====================================================================================
 //
@@ -89,7 +90,7 @@ spoutFrameCount::spoutFrameCount()
 	m_FrameTimeNumber = 0.0;
 	m_lastFrame = 0.0;
 	m_FrameStart = 0.0;
-	m_bIsNewFrame = false;
+	m_bIsNewFrame = true; // Assume true for apps without frame count
 	m_SenderFps = GetRefreshRate(); // Default sender fps is system refresh rate
 	m_millisForFrame = 0.0;
 

--- a/SPOUTSDK/SpoutGL/SpoutSenderNames.cpp
+++ b/SPOUTSDK/SpoutGL/SpoutSenderNames.cpp
@@ -77,6 +77,7 @@
 			   Change existing GetSender to FindSenderName.
 			 - Change duplicate FindSenderName to FindSender overload
 			   testing function
+	31.07.21 - Add m_senders size check in UpdateSender
 
 
 	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -738,7 +739,7 @@ bool spoutSenderNames::UpdateSender(const char *sendername, unsigned int width, 
 {
 	std::string namestring = sendername;
 
-	if (m_senders->find(namestring) == m_senders->end()) { // New sender
+	if (m_senders->size() == 0 || (m_senders->find(namestring) == m_senders->end())) { // New sender
 
 		// Create or open a shared memory map for this sender - allocate enough for the texture info
 		SpoutSharedMemory *senderInfoMem = new SpoutSharedMemory();

--- a/SPOUTSDK/SpoutGL/SpoutUtils.cpp
+++ b/SPOUTSDK/SpoutGL/SpoutUtils.cpp
@@ -641,7 +641,7 @@ namespace spoututils {
 #ifdef USE_CHRONO
 		end = std::chrono::steady_clock::now();
 		double elapsed = static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(end - start).count());
-		printf("    elapsed [%.4f] msec\n", elapsed / 1000.0);
+		// printf("    elapsed [%.4f] msec\n", elapsed / 1000.0);
 		// printf("elapsed [%.3f] u/sec\n", elapsed);
 		return elapsed;
 #else

--- a/SPOUTSDK/SpoutGL/SpoutUtils.cpp
+++ b/SPOUTSDK/SpoutGL/SpoutUtils.cpp
@@ -72,6 +72,7 @@
 		07.05.21 - Remove noisy warning from ReadPathFromRegistry
 		09.06.21 - Update Version to "2.007.002"
 		26.07.21 - Update Version to "2.007.003"
+		16.09.21 - Update Version to "2.007.004"
 
 
 
@@ -109,7 +110,7 @@ namespace spoututils {
 	std::chrono::steady_clock::time_point start;
 	std::chrono::steady_clock::time_point end;
 #endif
-	std::string SDKversion = "2.007.002"; // Spout SDK version number string
+	std::string SDKversion = "2.007.004"; // Spout SDK version number string
 
 	//
 	// Console management


### PR DESCRIPTION
Spout.cpp
. Revise CreateReceiver to avoid switch to active if the selected sender closes.
SpoutFrameCount.cpp
. Default m_bIsNewFrame, assume true to allow for apps without frame count
SpoutGL.cpp
. Correct LoadGLextensions to set no PBO availabliity if FBO fails
WriteDX11texture - unmap staging texture if data read fails
. ReadTextureData - allow for no FBO support for low end graphics
SpoutSenderNames.cpp
. Add m_senders size check in UpdateSender
SpoutUtils.cpp
. Update SDK Version to "2.007.004"

