### PR TITLE
Fix SpoutGL.cpp for VS2022 C++20

### DIFF
--- a/SPOUTSDK/SpoutGL/SpoutGL.cpp
+++ b/SPOUTSDK/SpoutGL/SpoutGL.cpp
@@ -390,9 +390,8 @@ bool spoutGL::OpenSpout(bool bRetest)
 {
 	// Return if already initialized and not re-testing compatibility
 	// Look for DirectX device to prevent repeat
-	if(spoutdx.GetDX11Device() > 0
-		&& m_hInteropDevice > 0
-		&& !bRetest)
+	if(spoutdx.GetDX11Device() != nullptr && m_hInteropDevice != nullptr
+            && !bRetest)
 		return true;
 
 	printf("\n"); // This is the start, so make a new line in the log


### PR DESCRIPTION
Due to "[Error on ordered pointer comparison against nullptr or 0](https://docs.microsoft.com/en-us/cpp/overview/cpp-conformance-improvements?view=msvc-170#error-on-ordered-pointer-comparison-against-nullptr-or-0)":

```
FAILED: SPOUTSDK/SpoutGL/CMakeFiles/Spout_static.dir/SpoutGL.cpp.obj 
D:\projects\Spout2\SPOUTSDK\SpoutGL\SpoutGL.cpp(393): error C7664: '>': ordered comparison of pointer and integer zero ('ID3D11Device *' and 'int')
D:\projects\Spout2\SPOUTSDK\SpoutGL\SpoutGL.cpp(394): error C7664: '>': ordered comparison of pointer and integer zero ('HANDLE' and 'int')
```