### PR TITLE
Fixes for compatibility with Clang

### DIFF
--- a/SPOUTSDK/SpoutGL/SpoutCopy.cpp
+++ b/SPOUTSDK/SpoutGL/SpoutCopy.cpp
@@ -1026,8 +1026,8 @@ void spoutCopy::rgba2rgbaResample(const void* source, void* dest,
 	unsigned int pixel, nearestMatch;
 	for (i = 0; i < destHeight; i++) {
 		for (j = 0; j < destWidth; j++) {
-			px = floor((float)j*x_ratio);
-			py = floor((float)i*y_ratio);
+			px = std::floor((float)j*x_ratio);
+			py = std::floor((float)i*y_ratio);
 			if (bInvert)
 				pixel = (destHeight - i - 1)*destWidth * 4 + j * 4; // flip vertically
 			else
@@ -1063,8 +1063,8 @@ void spoutCopy::rgba2rgbResample(const void* source, void* dest,
 	unsigned int pixel, nearestMatch;
 	for (i = 0; i < destHeight; i++) {
 		for (j = 0; j < destWidth; j++) {
-			px = floor((float)j*x_ratio);
-			py = floor((float)i*y_ratio);
+			px = std::floor((float)j*x_ratio);
+			py = std::floor((float)i*y_ratio);
 
 			if (bMirror) {
 				if (bInvert)
@@ -1102,8 +1102,8 @@ void spoutCopy::rgba2bgrResample(const void* source, void* dest,
 	unsigned int pixel, nearestMatch;
 	for (i = 0; i < destHeight; i++) {
 		for (j = 0; j < destWidth; j++) {
-			px = floor((float)j*x_ratio);
-			py = floor((float)i*y_ratio);
+			px = std::floor((float)j*x_ratio);
+			py = std::floor((float)i*y_ratio);
 			if (bInvert)
 				pixel = (destHeight - i - 1)*destWidth * 3 + j * 3; // flip vertically
 			else

--- a/SPOUTSDK/SpoutGL/SpoutCopy.h
+++ b/SPOUTSDK/SpoutGL/SpoutCopy.h
@@ -40,6 +40,7 @@
 #include <intrin.h> // for cpuid to test for SSE2
 #include <emmintrin.h> // for SSE2
 #include <tmmintrin.h> // for SSSE3
+#include <cmath> // for std::floor
 
 
 class SPOUT_DLLEXP spoutCopy {

--- a/SPOUTSDK/SpoutGL/SpoutFrameCount.cpp
+++ b/SPOUTSDK/SpoutGL/SpoutFrameCount.cpp
@@ -798,7 +798,7 @@ bool spoutFrameCount::CheckKeyedAccess(ID3D11Texture2D* pTexture)
 		IDXGIKeyedMutex* pDXGIKeyedMutex = nullptr;
 
 		// Check the keyed mutex
-		pTexture->QueryInterface(_uuidof(IDXGIKeyedMutex), (void**)&pDXGIKeyedMutex);
+		pTexture->QueryInterface(__uuidof(IDXGIKeyedMutex), (void**)&pDXGIKeyedMutex);
 		if (pDXGIKeyedMutex) {
 			HRESULT hr = pDXGIKeyedMutex->AcquireSync(0, 67); // TODO - link with SPOUT_WAIT_TIMEOUT
 			switch (hr) {
@@ -828,7 +828,7 @@ void spoutFrameCount::AllowKeyedAccess(ID3D11Texture2D* pTexture)
 	// 22-24 microseconds
 	if (pTexture) {
 		IDXGIKeyedMutex* pDXGIKeyedMutex;
-		pTexture->QueryInterface(_uuidof(IDXGIKeyedMutex), (void**)&pDXGIKeyedMutex);
+		pTexture->QueryInterface(__uuidof(IDXGIKeyedMutex), (void**)&pDXGIKeyedMutex);
 		if (pDXGIKeyedMutex) {
 			pDXGIKeyedMutex->ReleaseSync(0);
 			pDXGIKeyedMutex->Release();


### PR DESCRIPTION
- floor was not available without <cmath>. 
- proper form is __uuidof with two underscores (https://docs.microsoft.com/en-us/cpp/cpp/uuidof-operator) ; clang only knows that one.

cheers !