### PR TITLE
Fixes compatibility check to allow CPU sharing

### DIFF
--- a/SPOUTSDK/SpoutGL/SpoutGL.cpp
+++ b/SPOUTSDK/SpoutGL/SpoutGL.cpp
@@ -438,7 +438,7 @@ bool spoutGL::OpenSpout(bool bRetest)
 
 	m_bUseGLDX = false;
 	m_bTextureShare = false;
-	m_bCPUshare = false;
+	m_bCPUshare = true;
 
 	// DirectX capability is the minimum
 	if (!OpenDirectX()) {


### PR DESCRIPTION
As already discussed in #85, this flag change allows CPU sharing to be chosen as sharing method.