### PR TITLE
Update for MinGW

### DIFF
--- a/SPOUTSDK/SpoutGL/CMakeLists.txt
+++ b/SPOUTSDK/SpoutGL/CMakeLists.txt
@@ -60,7 +60,7 @@ set(SpoutLink
 )
 
 if(MINGW)
-  set(SpoutLink ${SpoutLink} winmm ucrt)
+  set(SpoutLink ${SpoutLink} winmm)
 endif()
 
 add_library(Spout_static STATIC ${SpoutSources} )

--- a/SPOUTSDK/SpoutGL/Spout.cpp
+++ b/SPOUTSDK/SpoutGL/Spout.cpp
@@ -279,11 +279,6 @@
 
 #include "Spout.h"
 
-#if !defined(_MSC_VER)
-#undef UNREFERENCED_PARAMETER
-#define UNREFERENCED_PARAMETER(x)
-#endif
-
 // Class: Spout
 //
 // <https://spout.zeal.co/>
@@ -1464,8 +1459,10 @@ bool Spout::GetAdapterInfo(char* renderadapter,
 	char* displaydescription, char* displayversion,
 	int maxsize, const bool bDX9)
 {
+#if defined(_MSC_VER)
 	// DirectX9 not supported
 	UNREFERENCED_PARAMETER(bDX9);
+#endif
 
 	if(!renderadapter
 	|| !renderdescription

--- a/SPOUTSDK/SpoutGL/SpoutGL.h
+++ b/SPOUTSDK/SpoutGL/SpoutGL.h
@@ -34,8 +34,8 @@
 #define __spoutGL__
 
 // Change the path as required
-#include "SpoutGLextensions.h" // include first so that gl.h is not included first if Glew is used
 #include "SpoutCommon.h" // for dll build and utilities
+#include "SpoutGLextensions.h" // include first so that gl.h is not included first if Glew is used
 #include "SpoutSenderNames.h" // for sender creation and update
 #include "SpoutDirectX.h" // for DX11 shared textures
 #include "SpoutFrameCount.h" // for mutex lock and new frame signal

--- a/SPOUTSDK/SpoutGL/SpoutUtils.cpp
+++ b/SPOUTSDK/SpoutGL/SpoutUtils.cpp
@@ -1262,7 +1262,11 @@ namespace spoututils {
 			size_t len = 0;
 			bool bSuccess = true;
 			errno_t err = 0;
+#if defined(_MSC_VER)
 			err = _dupenv_s(&appdatapath, &len, "APPDATA");
+#else
+			appdatapath = getenv("APPDATA");
+#endif
 			if (err == 0 && appdatapath) {
 				strcpy_s(logpath, MAX_PATH, appdatapath);
 				strcat_s(logpath, MAX_PATH, "\\Spout");


### PR DESCRIPTION
Linking with MSVC UCRT in MinGW causing Libzip error in MinGW, so in Flycast we are using `getenv` instead of `_dupenv_s` now

https://github.com/flyinghead/flycast/pull/1136