### PR TITLE
Link with comctl32 for MinGW

### DIFF
--- a/SPOUTSDK/SpoutGL/CMakeLists.txt
+++ b/SPOUTSDK/SpoutGL/CMakeLists.txt
@@ -62,7 +62,7 @@ set(SpoutLink
 )
 
 if(MINGW)
-  set(SpoutLink ${SpoutLink} winmm)
+  set(SpoutLink ${SpoutLink} comctl32 winmm)
 endif()
 
 add_library(Spout_static STATIC ${SpoutSources} )


### PR DESCRIPTION
This library is required with the recent addition of `TaskDialogIndirect`

https://github.com/leadedge/Spout2/blob/fe910076c3d365d9037970c175b2133122359624/SPOUTSDK/SpoutGL/SpoutUtils.cpp#L1612