### PR TITLE
Use TARGET_LINKER_FILE/TARGET_LINKER_FILE_NAME with SpoutLibrary

### DIFF
--- a/SPOUTSDK/SpoutLibrary/CMakeLists.txt
+++ b/SPOUTSDK/SpoutLibrary/CMakeLists.txt
@@ -24,18 +24,13 @@ target_compile_definitions(SpoutLibrary
     SPOUT_BUILD_DLL
 )
 
-get_property(GeneratorisMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
-if(GeneratorisMultiConfig)
-	set(ConfigOutputDirectory $<CONFIG>/)
-endif()
-
 # Win32 or x64 build
 if(CMAKE_SIZEOF_VOID_P EQUAL 4)
 
 	# Copy Win32 binaries to the BUILD/Binaries folder
 	add_custom_command(TARGET SpoutLibrary POST_BUILD
 		COMMAND ${CMAKE_COMMAND} -E 
-		copy ${CMAKE_CURRENT_BINARY_DIR}/${ConfigOutputDirectory}SpoutLibrary.lib ${CMAKE_BINARY_DIR}/Binaries/Win32/SpoutLibrary.lib
+		copy $<TARGET_LINKER_FILE:SpoutLibrary> ${CMAKE_BINARY_DIR}/Binaries/Win32/$<TARGET_LINKER_FILE_NAME:SpoutLibrary>
 	)
 	add_custom_command(TARGET SpoutLibrary POST_BUILD
 	    COMMAND ${CMAKE_COMMAND} -E 
@@ -47,7 +42,7 @@ else()
 	# Copy x64 binaries to the BUILD/Binaries folder
 	add_custom_command(TARGET SpoutLibrary POST_BUILD
 		COMMAND ${CMAKE_COMMAND} -E 
-		copy ${CMAKE_CURRENT_BINARY_DIR}/${ConfigOutputDirectory}SpoutLibrary.lib ${CMAKE_BINARY_DIR}/Binaries/x64/SpoutLibrary.lib
+		copy $<TARGET_LINKER_FILE:SpoutLibrary> ${CMAKE_BINARY_DIR}/Binaries/x64/$<TARGET_LINKER_FILE_NAME:SpoutLibrary>
 	)
 	add_custom_command(TARGET SpoutLibrary POST_BUILD
 	    COMMAND ${CMAKE_COMMAND} -E 


### PR DESCRIPTION
https://cmake.org/cmake/help/v3.27/manual/cmake-generator-expressions.7.html#genex:TARGET_LINKER_FILE

>  $<TARGET_LINKER_FILE:tgt>
File used when linking to the tgt target. This will usually be the library that tgt represents (.a, .lib, .so), but for a shared library on DLL platforms, it would be the .lib import library associated with the DLL.

Fix MINGW which generates a file named `libSpoutLibrary.dll.a` and not `SpoutLibrary.lib`