### PR TITLE
Add support for cross compiling for Windows on ARM with Visual Studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ OPTION(SPOUT_BUILD_ARM "Build for Windows on ARM" OFF)
 if(SPOUT_BUILD_ARM)
 	# Use SS2NEON so SIMD code doesn't have to be rewritten for ARM
 	# Download sse2neon.h
-	File(DOWNLOAD https://github.com/DLTcollab/sse2neon/blob/master/sse2neon.h ${PROJECT_SOURCE_DIR}/SPOUTSDK/sse2neon/sse2neon.h)
+	File(DOWNLOAD https://github.com/DLTcollab/sse2neon/raw/master/sse2neon.h ${PROJECT_SOURCE_DIR}/SPOUTSDK/sse2neon/sse2neon.h)
 	# Add compiler include_directory and /Zc:preprocessor define
 	include_directories(SPOUTSDK/sse2neon)
 	add_compile_options(/Zc:preprocessor)

--- a/SPOUTSDK/SpoutGL/SpoutCommon.h
+++ b/SPOUTSDK/SpoutGL/SpoutCommon.h
@@ -87,6 +87,7 @@
 // __movsd intrinsic not defined
 //
 #if defined _M_ARM64
+#include <memory.h>
 inline void __movsd(unsigned long* Destination,
 	const unsigned long* Source, size_t Count)
 {


### PR DESCRIPTION
Comments:
- SSE2NEON is a header-only library. It was copied and pasted, but git submodules could be used if preferred. This is their repo: https://github.com/DLTcollab/sse2neon
- `/Zc:preprocessor` is needed for sse2neon, but since the public API surface of Spout does not include the intrinsic headers this won't affect upstream code that use Spout2

Fixes #102