### PR TITLE
Fix MinGW TaskDialogIndirect could not be located error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,15 @@ if(NOT SKIP_INSTALL_ALL)
 			)
 		endif()
 
+		if(MINGW)
+			install(
+				FILES
+				SPOUTSDK/MinGW/modern-style-manifest.rc
+				DESTINATION
+					${CMAKE_INSTALL_PREFIX}/include/MinGW
+			)
+		endif()
+
 	endif()
 
 endif()

--- a/SPOUTSDK/MinGW/modern-style-manifest.rc
+++ b/SPOUTSDK/MinGW/modern-style-manifest.rc
@@ -1,0 +1,20 @@
+#include <windows.h>
+
+CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST
+BEGIN
+    "<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes""?>"
+    "<assembly xmlns=""urn:schemas-microsoft-com:asm.v1"" manifestVersion=""1.0"">"
+    "<dependency>"
+    "    <dependentAssembly>"
+    "        <assemblyIdentity"
+    "            type=""win32"""
+    "            name=""Microsoft.Windows.Common-Controls"""
+    "            version=""6.0.0.0"""
+    "            processorArchitecture=""*"""
+    "            publicKeyToken=""6595b64144ccf1df"""
+    "            language=""*"""
+    "        />"
+    "    </dependentAssembly>"
+    "</dependency>"
+    "</assembly>"
+END

--- a/SPOUTSDK/SpoutDirectX/SpoutDX/CMakeLists.txt
+++ b/SPOUTSDK/SpoutDirectX/SpoutDX/CMakeLists.txt
@@ -91,6 +91,18 @@ if(MINGW)
   set(OUTPUT_STATIC_LIB "libSpoutDX_static.a")
   set(OUTPUT_SHARED_LIB "libSpoutDX.dll")
   set(OUTPUT_IMPORT_LIB "libSpoutDX.dll.a")
+
+  # Linking Comctl32 Version 6 for TaskDialogIndirect
+  set(resource_file MinGW/modern-style-manifest.rc)
+  foreach(target IN ITEMS SpoutDX_static SpoutDX)
+    target_sources(${target}
+      INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../${resource_file}>
+        $<INSTALL_INTERFACE:include/${resource_file}>
+      PRIVATE
+        ../../${resource_file}
+    )
+  endforeach()
 else()
   set(OUTPUT_STATIC_LIB "SpoutDX_static.lib")
   set(OUTPUT_SHARED_LIB "SpoutDX.dll")

--- a/SPOUTSDK/SpoutGL/CMakeLists.txt
+++ b/SPOUTSDK/SpoutGL/CMakeLists.txt
@@ -96,6 +96,18 @@ if(MINGW)
   set(OUTPUT_STATIC_LIB "libSpout_static.a")
   set(OUTPUT_SHARED_LIB "libSpout.dll")
   set(OUTPUT_IMPORT_LIB "libSpout.dll.a")
+
+  # Linking Comctl32 Version 6 for TaskDialogIndirect
+  set(resource_file MinGW/modern-style-manifest.rc)
+  foreach(target IN ITEMS Spout_static Spout)
+    target_sources(${target}
+      INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../${resource_file}>
+        $<INSTALL_INTERFACE:include/${resource_file}>
+      PRIVATE
+        ../${resource_file}
+    )
+  endforeach()
 else()
   set(OUTPUT_STATIC_LIB "Spout_static.lib")
   set(OUTPUT_SHARED_LIB "Spout.dll")


### PR DESCRIPTION
<img width="453" alt="image" src="https://github.com/leadedge/Spout2/assets/602245/412a1519-ad46-4209-9236-b184539e3764">

When building with MinGW, the `manifestdependency` linker command is not supported, so it cannot link with the Comctl32 version 6.

The fix is to include a manifest file manually in the resources.