### PR TITLE
Add missing parameter to spoututils::EndTiming

### DIFF
--- a/SPOUTSDK/SpoutGL/SpoutUtils.cpp
+++ b/SPOUTSDK/SpoutGL/SpoutUtils.cpp
@@ -1510,7 +1510,7 @@ namespace spoututils {
 
 	// Stop timing and return microseconds elapsed.
 	// Console output can be enabled for quick timing tests.
-	double EndTiming() {
+	double EndTiming(bool microseconds) {
 		endcount = GetCounter();
 		return (endcount-startcount);
 	}


### PR DESCRIPTION
When USE_CHRONO is not defined