### PR TITLE
Add <algorithm> include header for std::remove

### DIFF
--- a/SPOUTSDK/SpoutGL/SpoutUtils.h
+++ b/SPOUTSDK/SpoutGL/SpoutUtils.h
@@ -58,6 +58,7 @@
 #include <Shellapi.h> // for shellexecute
 #include <Commctrl.h> // For TaskDialogIndirect
 #include <math.h> // for round
+#include <algorithm> // for string character remove
 
 //
 // C++11 timer is only available for MS Visual Studio 2015 and above.


### PR DESCRIPTION
Without this change, with MinGW, I have this error:
```
D:/a/flycast/flycast/external/Spout2/SPOUTSDK/SpoutGL/SpoutUtils.cpp: In function 'std::string spoututils::GetSDKversion(int*)':
D:/a/flycast/flycast/external/Spout2/SPOUTSDK/SpoutGL/SpoutUtils.cpp:292:56: error: cannot convert 'std::__cxx11::basic_string<char>::iterator' to 'const char*'
  292 |                         str.erase(std::remove(str.begin(), str.end(), '.'), str.end());
      |                                               ~~~~~~~~~^~
      |                                                        |
      |                                                        std::__cxx11::basic_string<char>::iterator
```