### PR TITLE
Fix duplicate symbol linker errors

### DIFF
--- a/SPOUTSDK/SpoutDirectX/SpoutDX/CMakeLists.txt
+++ b/SPOUTSDK/SpoutDirectX/SpoutDX/CMakeLists.txt
@@ -21,22 +21,9 @@ project(SpoutDX)
 # Source and header files
 set(SpoutDX_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/SpoutDX.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/../../SpoutGL/SpoutCopy.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/../../SpoutGL/SpoutDirectX.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/../../SpoutGL/SpoutFrameCount.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/../../SpoutGL/SpoutSenderNames.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/../../SpoutGL/SpoutSharedMemory.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/../../SpoutGL/SpoutUtils.cpp
 )
 set(SpoutDX_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/SpoutDX.h
-	${CMAKE_CURRENT_SOURCE_DIR}/../../SpoutGL/SpoutCommon.h
-	${CMAKE_CURRENT_SOURCE_DIR}/../../SpoutGL/SpoutCopy.h
-	${CMAKE_CURRENT_SOURCE_DIR}/../../SpoutGL/SpoutDirectX.h
-	${CMAKE_CURRENT_SOURCE_DIR}/../../SpoutGL/SpoutFrameCount.h
-	${CMAKE_CURRENT_SOURCE_DIR}/../../SpoutGL/SpoutSenderNames.h
-	${CMAKE_CURRENT_SOURCE_DIR}/../../SpoutGL/SpoutSharedMemory.h
-	${CMAKE_CURRENT_SOURCE_DIR}/../../SpoutGL/SpoutUtils.h
 )
 
 #--------------------------------------

--- a/SPOUTSDK/SpoutDirectX/SpoutDX/SpoutDX9/CMakeLists.txt
+++ b/SPOUTSDK/SpoutDirectX/SpoutDX/SpoutDX9/CMakeLists.txt
@@ -14,18 +14,9 @@ project(SpoutDX9)
 # Source and header files
 set(SpoutDX9_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/SpoutDX9.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/../../../SpoutGL/SpoutFrameCount.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/../../../SpoutGL/SpoutSenderNames.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/../../../SpoutGL/SpoutSharedMemory.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/../../../SpoutGL/SpoutUtils.cpp
 )
 set(SpoutDX9_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/SpoutDX9.h
-	${CMAKE_CURRENT_SOURCE_DIR}/../../../SpoutGL/SpoutCommon.h
-	${CMAKE_CURRENT_SOURCE_DIR}/../../../SpoutGL/SpoutFrameCount.h
-	${CMAKE_CURRENT_SOURCE_DIR}/../../../SpoutGL/SpoutSenderNames.h
-	${CMAKE_CURRENT_SOURCE_DIR}/../../../SpoutGL/SpoutSharedMemory.h
-	${CMAKE_CURRENT_SOURCE_DIR}/../../../SpoutGL/SpoutUtils.h
 )
 
 #--------------------------------------


### PR DESCRIPTION
Fix duplicate symbol linker errors in SpoutDX/SpoutDX9 builds.

When using ClangCL, the build is failing with duplicate symbol errors because the source files are being compiled twice:
- Once when building Spout_static
- Again when building SpoutDX and SpoutDX9

Since SpoutDX and SpoutDX9 already link against Spout_static, these files shouldn't be recompiled.

Build log with the errors: https://github.com/scribam/Spout2/actions/runs/27843104640/job/82406348218