### PR TITLE
Define NOMINMAX and WIN32_LEAN_AND_MEAN

### DIFF
--- a/SPOUTSDK/SpoutGL/SpoutCopy.cpp
+++ b/SPOUTSDK/SpoutGL/SpoutCopy.cpp
@@ -1301,10 +1301,10 @@ void spoutCopy::rgba2rgbResample(const void* source, void* dest,
     const float y_ratio = float(sourceHeight)/float(destHeight);
 
     for (unsigned int j = 0; j < destWidth; j++)
-        xTable[j] = min((unsigned int)(j * x_ratio), sourceWidth - 1);
+        xTable[j] = std::min((unsigned int)(j * x_ratio), sourceWidth - 1);
 
     for (unsigned int i = 0; i < destHeight; i++)
-        yTable[i] = min((unsigned int)(i * y_ratio), sourceHeight - 1);
+        yTable[i] = std::min((unsigned int)(i * y_ratio), sourceHeight - 1);
 
     // Precompute source row offsets
     std::vector<unsigned int> rowOffset(destHeight);

--- a/SPOUTSDK/SpoutGL/SpoutUtils.h
+++ b/SPOUTSDK/SpoutGL/SpoutUtils.h
@@ -46,6 +46,8 @@
 #include <stdint.h> // for _uint32 etc
 #endif
 
+#define NOMINMAX
+#define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
 #include <windows.h>
 #include <stdio.h> // for console
 #include <iostream> // std::cout, std::end
@@ -60,6 +62,7 @@
 #include <commctrl.h> // For TaskDialogIndirect
 #include <math.h> // for round
 #include <algorithm> // for string character remove
+#include <timeapi.h> // for timeGetDevCaps, timeBeginPeriod, timeEndPeriod
 
 //
 // C++11 timer is only available for MS Visual Studio 2015 and above.


### PR DESCRIPTION
`NOMINMAX` allows to use `std::min` without build errors like:
```
D:\a\Spout2\Spout2\SPOUTSDK\SpoutGL\SpoutCopy.cpp(1304,26): error C2589: '(': illegal token on right side of '::' [D:\a\Spout2\Spout2\BUILD\SPOUTSDK\SpoutGL\Spout.vcxproj]
D:\a\Spout2\Spout2\SPOUTSDK\SpoutGL\SpoutCopy.cpp(1307,26): error C2589: '(': illegal token on right side of '::' [D:\a\Spout2\Spout2\BUILD\SPOUTSDK\SpoutGL\Spout.vcxproj]
```
`WIN32_LEAN_AND_MEAN` excludes rarely-used stuff from Windows headers which reduces build time. `timeapi.h` is added because it is not transitively included anymore through `windows.h` and it is required for timeGetDevCaps, timeBeginPeriod, timeEndPeriod functions