### PR TITLE
Enumerate sender names whose first byte is non-ASCII

### DIFF
--- a/SPOUTSDK/SpoutGL/SpoutSenderNames.cpp
+++ b/SPOUTSDK/SpoutGL/SpoutSenderNames.cpp
@@ -1080,14 +1080,18 @@ void spoutSenderNames::readSenderSetFromBuffer(const char* buffer, std::set<std:
 		// At the end of the map there will be a null in the data.
 		// Must use a character array to ensure testing for null.
 		strncpy_s(name, buf, SpoutMaxSenderNameLen);
-		if(name[0] > 0) {
+		// Cast to unsigned char before the comparison. char is signed on MSVC, so a
+		// name whose first byte is >= 0x80 (e.g. a UTF-8 / non-ASCII sender name) is
+		// negative and would be dropped here, and would also end the loop early and
+		// hide any senders stored after it.
+		if((unsigned char)name[0] > 0) {
 			// insert name into set
 			SenderNames.insert(&name[0]);
 		}
 		// increment by 256 bytes for the next name
 		buf += SpoutMaxSenderNameLen;
 		i++;
-	} while (name[0] > 0 && i < maxSenders); // maxSenders has to be passed because this function is static
+	} while ((unsigned char)name[0] > 0 && i < maxSenders); // maxSenders has to be passed because this function is static
 
 }
 


### PR DESCRIPTION
Re-targets #140 to the `beta` branch, as requested in the Master branch README (changes accumulate in `beta` before moving to Master for a release). The change is identical; #140 was opened against `master` and is being closed in favour of this one.

## Problem

`readSenderSetFromBuffer` tests `name[0] > 0` to decide whether a sender-name slot is populated. `char` is signed on MSVC, so a name whose first byte is >= 0x80 (any UTF-8 / non-ASCII name) is negative:

- the name is dropped from the enumerated set (`GetSender`, `GetSenderNames`, `GetSenderCount` all read this set), and
- the `do { … } while (name[0] > 0 …)` loop terminates at that slot, so any senders stored after it are hidden too.

The sender itself is created correctly — only enumeration is affected.

## Fix

Cast the first byte to `unsigned char` in both comparisons.

## Observed behaviour

The sender was an OBS Spout output filter; the receivers were Shoost and a second OBS Spout source, both of which read this `sendernames` set.

| Sender name | First byte | Enumerated (before) | After |
|---|---|---|---|
| `Gradient -3457` | ASCII | ✅ | ✅ |
| `Logo demo - 6784` | ASCII (has spaces) | ✅ | ✅ |
| `Spout_OBS_Filter-场景2` | ASCII (CJK later) | ✅ | ✅ |
| `场景 2 - 167790` | CJK (0xE5…) | ❌ | ✅ |
| `中文 logo` | CJK (0xE5…) | ❌ | ✅ |

The deciding factor is purely the sign of the first byte: the same characters placed later in the name enumerate fine (see `Spout_OBS_Filter-场景2`).
