### PR TITLE
Use HandleToLong on all archs

### DIFF
--- a/SPOUTSDK/SpoutGL/SpoutSenderNames.cpp
+++ b/SPOUTSDK/SpoutGL/SpoutSenderNames.cpp
@@ -624,11 +624,7 @@ bool spoutSenderNames::SetSenderInfo(const char* sendername, unsigned int width,
 		
 	info.width       = (uint32_t)width;
 	info.height      = (uint32_t)height;
-#ifdef _M_X64
 	info.shareHandle = (uint32_t)(HandleToLong(dxShareHandle));
-#else
-	info.shareHandle = (uint32_t)dxShareHandle;
-#endif
 	info.format      = (uint32_t)dwFormat;
 	
 	// Texture usage - unused


### PR DESCRIPTION
- HandleToLong can be safely use on x86
- x64 will still use HandleToLong

ARM64 will benefit from this change: 
- Fix MSVC warning: `D:\a\Spout2\Spout2\SPOUTSDK\SpoutGL\SpoutSenderNames.cpp(630,21): warning C4311: 'type cast': pointer truncation from 'HANDLE' to 'uint32_t' [D:\a\Spout2\Spout2\BUILD\SPOUTSDK\SpoutGL\Spout.vcxproj]`
- Fix ClangCL warning: `D:\a\Spout2\Spout2\SPOUTSDK\SpoutGL\SpoutSenderNames.cpp(630,21): warning : cast to smaller integer type 'unsigned int' from 'void *' [-Wvoid-pointer-to-int-cast] [D:\a\Spout2\Spout2\BUILD\SPOUTSDK\SpoutGL\Spout_static.vcxproj]`
- Fix clangarm64 error:
```C:\a\_temp\msys64\clangarm64\bin\c++.exe -DSPOUT_BUILD_STATIC -IC:/a/Spout2/Spout2/SPOUTSDK/sse2neon -IC:/a/Spout2/Spout2/SPOUTSDK/SpoutGL  -MD -MT SPOUTSDK/SpoutGL/CMakeFiles/Spout_static.dir/SpoutSenderNames.cpp.obj -MF SPOUTSDK\SpoutGL\CMakeFiles\Spout_static.dir\SpoutSenderNames.cpp.obj.d -o SPOUTSDK/SpoutGL/CMakeFiles/Spout_static.dir/SpoutSenderNames.cpp.obj -c C:/a/Spout2/Spout2/SPOUTSDK/SpoutGL/SpoutSenderNames.cpp
C:/a/Spout2/Spout2/SPOUTSDK/SpoutGL/SpoutSenderNames.cpp:630:21: error: cast from pointer to smaller type 'uint32_t' (aka 'unsigned int') loses information
  630 |         info.shareHandle = (uint32_t)dxShareHandle;
      |                            ^~~~~~~~~~~~~~~~~~~~~~~
1 error generated.